### PR TITLE
Bazel Version: update README to match Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This docker container provides everything needed to build and test Angular appli
 - npm 5.5.1
 - yarn 1.3.2
 - Java 8 (for Closure Compiler and Bazel)
-- Bazel build tool v0.8.1 - http://bazel.build
+- Bazel build tool v0.9.0 - http://bazel.build
 - Google Chrome 63.0.3239.84
 - Mozilla Firefox 47.0.1
 - xvfb (virtual framebuffer) for headless testing


### PR DESCRIPTION
Note that since Bazel's now on a monthly release cycle, versions move fast. The current stable is [0.11.1](https://github.com/bazelbuild/bazel/releases/tag/0.11.1)